### PR TITLE
Add total profit to history command in wallet-tool

### DIFF
--- a/wallet-tool.py
+++ b/wallet-tool.py
@@ -471,6 +471,7 @@ elif method == 'history':
         now = jm_single().bc_interface.rpc('getblock', [bestblockhash])['time']
     print('     %s best block is %s' % (datetime.datetime.fromtimestamp(now)
         .strftime("%Y-%m-%d %H:%M"), bestblockhash))
+    print('total profit = ' + str(float(balance - sum(deposits)) / float(100000000)) + ' BTC')
     try:
         #https://gist.github.com/chris-belcher/647da261ce718fc8ca10
         import numpy as np


### PR DESCRIPTION
**This adds the total profit from all successfull coinjoins to the history command in wallet-tool**

This is useful because before you had to manually add all deposits and subtract them from the wallet balance. It displays prior to the annual interest rate and will work without numpy installed.

To see the profit enter this command:

> python wallet-tool.py wallet.json history

It looks like this:

> total profit = 0.00020829 BTC
> continuously compounded equivalent annual interest rate = 6.79291165341 %